### PR TITLE
Wrap keys and tokens and add copy buttons for individual and group co…

### DIFF
--- a/src/pages/DataHub/DataHub.scss
+++ b/src/pages/DataHub/DataHub.scss
@@ -17,3 +17,8 @@
     }
   }
 }
+
+.copy-button {
+  display: inline-flex;
+  margin-left: 10px;
+}

--- a/src/pages/DataHub/DataHub.tsx
+++ b/src/pages/DataHub/DataHub.tsx
@@ -154,6 +154,10 @@ export const DataHub = () => {
     }
   };
 
+  const copyIndividualKey = async (inputString: string) => {
+    await navigator.clipboard.writeText(inputString);
+  };
+
   const renderModalContent = () => {
     if (creatingToken) return <div>Creating token</div>;
     if (newTokenValue) {
@@ -163,6 +167,12 @@ export const DataHub = () => {
             <strong>Token ID:</strong> {tokens[tokens.length - 1]?.id}
             <br />
             <strong>API Key:</strong> {newTokenValue}
+            <Button
+              style={{ display: 'inline-flex', marginLeft: '10px' }}
+              onClick={() => copyIndividualKey(newTokenValue)}
+            >
+              ⧉
+            </Button>
           </p>
           <p>This is your only chance to copy it!</p>
         </div>

--- a/src/pages/DataHub/DataHub.tsx
+++ b/src/pages/DataHub/DataHub.tsx
@@ -167,10 +167,7 @@ export const DataHub = () => {
             <strong>Token ID:</strong> {tokens[tokens.length - 1]?.id}
             <br />
             <strong>API Key:</strong> {newTokenValue}
-            <Button
-              style={{ display: 'inline-flex', marginLeft: '10px' }}
-              onClick={() => copyIndividualKey(newTokenValue)}
-            >
+            <Button className="copy-button" onClick={() => copyIndividualKey(newTokenValue)}>
               ⧉
             </Button>
           </p>

--- a/src/pages/S3/S3.tsx
+++ b/src/pages/S3/S3.tsx
@@ -10,6 +10,23 @@ export const S3 = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const copyIndividualKey = async (inputString: string) => {
+    await navigator.clipboard.writeText(inputString);
+  };
+
+  const copyAllKeys = async (
+    access_key: string,
+    secret_access_key: string,
+    session_token: string,
+  ) => {
+    const credentials: string =
+      `ACCESS_KEY_ID=${access_key}\n` +
+      `SECRET_ACCESS_KEY=${secret_access_key}\n` +
+      `SESSION_TOKEN=${session_token}`;
+
+    await navigator.clipboard.writeText(credentials);
+  };
+
   const handleCreateToken = async () => {
     try {
       setLoading(true);
@@ -31,14 +48,52 @@ export const S3 = () => {
 
       {newTokenValue ? (
         <div className="new-token-message">
+          <Button
+            onClick={() =>
+              copyAllKeys(
+                newTokenValue.accessKeyId,
+                newTokenValue.secretAccessKey,
+                newTokenValue.sessionToken,
+              )
+            }
+          >
+            Copy credentials to .env file
+          </Button>
           <p>
-            <strong>Access Key ID:</strong> {newTokenValue.accessKeyId}
+            <strong>Access Key ID:</strong>
+            <span style={{ wordWrap: 'break-word', wordBreak: 'break-word' }}>
+              {newTokenValue.accessKeyId}
+            </span>
+            <Button
+              style={{ display: 'inline-flex', marginLeft: '10px' }}
+              onClick={() => copyIndividualKey(newTokenValue.accessKeyId)}
+            >
+              ⧉
+            </Button>
           </p>
           <p>
-            <strong>Secret Access Key:</strong> {newTokenValue.secretAccessKey}
+            <strong>Secret Access Key:</strong>
+            <span style={{ wordWrap: 'break-word', wordBreak: 'break-word' }}>
+              {newTokenValue.secretAccessKey}
+            </span>
+            <Button
+              style={{ display: 'inline-flex', marginLeft: '10px' }}
+              onClick={() => copyIndividualKey(newTokenValue.secretAccessKey)}
+            >
+              ⧉
+            </Button>
           </p>
           <p>
-            <strong>Session Token:</strong> {newTokenValue.sessionToken}
+            <strong>Session Token:</strong>{' '}
+            <span style={{ wordWrap: 'break-word', wordBreak: 'break-word' }}>
+              {newTokenValue.sessionToken}
+            </span>
+            <Button
+              style={{ display: 'inline-flex', marginLeft: '10px' }}
+              onClick={() => copyIndividualKey(newTokenValue.sessionToken)}
+            >
+              ⧉
+            </Button>
           </p>
           <p>
             <strong>Expiration:</strong> {newTokenValue.expiration}

--- a/src/pages/S3/S3.tsx
+++ b/src/pages/S3/S3.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import './styles.scss';
 
 import { Button } from '@/components/Button/Button';
 import { useWorkspace } from '@/hooks/useWorkspace';
@@ -14,15 +15,11 @@ export const S3 = () => {
     await navigator.clipboard.writeText(inputString);
   };
 
-  const copyAllKeys = async (
-    access_key: string,
-    secret_access_key: string,
-    session_token: string,
-  ) => {
+  const copyAllKeys = async (accessKey: string, secretAccessKey: string, sessionToken: string) => {
     const credentials: string =
-      `ACCESS_KEY_ID=${access_key}\n` +
-      `SECRET_ACCESS_KEY=${secret_access_key}\n` +
-      `SESSION_TOKEN=${session_token}`;
+      `ACCESS_KEY_ID=${accessKey}\n` +
+      `SECRET_ACCESS_KEY=${secretAccessKey}\n` +
+      `SESSION_TOKEN=${sessionToken}`;
 
     await navigator.clipboard.writeText(credentials);
   };
@@ -61,11 +58,9 @@ export const S3 = () => {
           </Button>
           <p>
             <strong>Access Key ID:</strong>
-            <span style={{ wordWrap: 'break-word', wordBreak: 'break-word' }}>
-              {newTokenValue.accessKeyId}
-            </span>
+            <span className="aws-creds">{newTokenValue.accessKeyId}</span>
             <Button
-              style={{ display: 'inline-flex', marginLeft: '10px' }}
+              className="copy-button"
               onClick={() => copyIndividualKey(newTokenValue.accessKeyId)}
             >
               ⧉
@@ -73,11 +68,9 @@ export const S3 = () => {
           </p>
           <p>
             <strong>Secret Access Key:</strong>
-            <span style={{ wordWrap: 'break-word', wordBreak: 'break-word' }}>
-              {newTokenValue.secretAccessKey}
-            </span>
+            <span className="aws-creds">{newTokenValue.secretAccessKey}</span>
             <Button
-              style={{ display: 'inline-flex', marginLeft: '10px' }}
+              className="copy-button"
               onClick={() => copyIndividualKey(newTokenValue.secretAccessKey)}
             >
               ⧉
@@ -85,11 +78,9 @@ export const S3 = () => {
           </p>
           <p>
             <strong>Session Token:</strong>
-            <span style={{ wordWrap: 'break-word', wordBreak: 'break-word' }}>
-              {newTokenValue.sessionToken}
-            </span>
+            <span className="aws-creds">{newTokenValue.sessionToken}</span>
             <Button
-              style={{ display: 'inline-flex', marginLeft: '10px' }}
+              className="copy-button"
               onClick={() => copyIndividualKey(newTokenValue.sessionToken)}
             >
               ⧉

--- a/src/pages/S3/S3.tsx
+++ b/src/pages/S3/S3.tsx
@@ -84,7 +84,7 @@ export const S3 = () => {
             </Button>
           </p>
           <p>
-            <strong>Session Token:</strong>{' '}
+            <strong>Session Token:</strong>
             <span style={{ wordWrap: 'break-word', wordBreak: 'break-word' }}>
               {newTokenValue.sessionToken}
             </span>

--- a/src/pages/S3/S3.tsx
+++ b/src/pages/S3/S3.tsx
@@ -57,7 +57,7 @@ export const S3 = () => {
             Copy credentials to .env file
           </Button>
           <p>
-            <strong>Access Key ID:</strong>
+            <strong className="key-name">Access Key ID: </strong>
             <span className="aws-creds">{newTokenValue.accessKeyId}</span>
             <Button
               className="copy-button"
@@ -67,7 +67,7 @@ export const S3 = () => {
             </Button>
           </p>
           <p>
-            <strong>Secret Access Key:</strong>
+            <strong className="key-name">Secret Access Key: </strong>
             <span className="aws-creds">{newTokenValue.secretAccessKey}</span>
             <Button
               className="copy-button"
@@ -77,7 +77,7 @@ export const S3 = () => {
             </Button>
           </p>
           <p>
-            <strong>Session Token:</strong>
+            <strong className="key-name">Session Token: </strong>
             <span className="aws-creds">{newTokenValue.sessionToken}</span>
             <Button
               className="copy-button"

--- a/src/pages/S3/styles.scss
+++ b/src/pages/S3/styles.scss
@@ -1,3 +1,7 @@
+.key-name {
+  white-space: nowrap;
+}
+
 .aws-creds {
   word-wrap: break-word;
   word-break: break-word;

--- a/src/pages/S3/styles.scss
+++ b/src/pages/S3/styles.scss
@@ -1,0 +1,9 @@
+.aws-creds {
+  word-wrap: break-word;
+  word-break: break-word;
+}
+
+.copy-button {
+  display: inline-flex;
+  margin-left: 10px;
+}


### PR DESCRIPTION
## Easily Copy AWS S3 Credentials
- Wrap text for AWS credentials to avoid extending off the display
- Add buttons to copy individual AWS credentials
- Add button to copy complete AWS credentials in a .env file structure
- Also add similar button to DataHub API key when generated