### PR TITLE
add styling for disabled buttons

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -8,9 +8,9 @@ type CustomButtonProps = {
   className?: string;
 } & RadixButtonProps;
 
-export const Button = ({ icon, children, className, ...rest }: CustomButtonProps) => {
+export const Button = ({ icon, children, className = '', ...rest }: CustomButtonProps) => {
   return (
-    <RadixButton className={className} style={{ cursor: 'pointer' }} {...rest}>
+    <RadixButton className={className} {...rest}>
       {icon && <span style={{ marginRight: '0.5rem', display: 'inline-flex' }}>{icon}</span>}
       {children}
     </RadixButton>

--- a/src/index.scss
+++ b/src/index.scss
@@ -38,6 +38,13 @@ button {
   border: none;
 }
 
+button:disabled {
+  background-color: #ccc;
+  color: #666;
+  cursor: not-allowed;
+  pointer-events: all;
+}
+
 h1,
 h2,
 h3,

--- a/src/pages/DataLoader/styles.scss
+++ b/src/pages/DataLoader/styles.scss
@@ -104,7 +104,6 @@ $width: 600px;
   &-tabs {
     display: flex;
     justify-content: left;
-    border-bottom: 1px solid lightgrey;
     margin-bottom: 25px;
     width: 100%;
 
@@ -113,17 +112,14 @@ $width: 600px;
       display: flex;
       justify-content: center;
       transition: all 0.2s linear;
-      background-color: rgb(158 158 158);
-      color: grey;
+      background-color: #fff;
+      color: black;
       cursor: pointer;
-
-      &:hover {
-        background-color: lightgrey;
-      }
     }
 
     &__tab.active {
       background-color: white;
+      border-bottom: 2px solid var(--button-bg);
       color: black;
       font-weight: 600;
       cursor: not-allowed;

--- a/src/pages/LinkedAccounts/LinkedAccounts.tsx
+++ b/src/pages/LinkedAccounts/LinkedAccounts.tsx
@@ -172,7 +172,7 @@ const LinkedAccounts = () => {
         </div>
         <div className="linked-accounts__account-input">
           <input
-            disabled={account.linked}
+            disabled={account.linked || !isWorkspaceOwner}
             placeholder="Enter your API key"
             type={account.linked ? 'password' : 'text'}
             value={account.value}
@@ -475,6 +475,20 @@ const LinkedAccounts = () => {
       )}
       <div className="content-page">
         {renderHeader()}
+        {!isWorkspaceOwner && (
+          <div
+            style={{
+              backgroundColor: '#fff8e1',
+              color: '#8a6d3b',
+              padding: '1rem',
+              borderRadius: '5px',
+              marginBottom: '1rem',
+              border: '1px solid #faebcc',
+            }}
+          >
+            You have view-only access. Only workspace owners can edit or link API keys.
+          </div>
+        )}
         {<div className="linked-accounts__error">{error}</div>}
         <div className="linked-accounts">
           {data.map((account) => (


### PR DESCRIPTION
- Extended styling for buttons when they are disabled.
- Added a popup message if a user is only a member of a workspace and they access linked-accounts tab.
- Amended styling of the tabs between Data Loader and Logs

This is currently on `dev`.

If you click on `jl-0002` (isaac) you should not have access to input anything for linked-accounts as you are only a member. On your own workspace you may input.

