### PR TITLE
Dataloader bug fix

### DIFF
--- a/src/components/WorkspaceMenu/navigation.tsx
+++ b/src/components/WorkspaceMenu/navigation.tsx
@@ -18,7 +18,7 @@ export interface NavItem {
 
 export const navItems: NavItem[] = [
   { label: 'Members', icon: membersIcon, content: <Members /> },
-  { label: 'Data Loader', icon: uploadIcon, content: <DataLoader /> },
+  { label: 'Metadata Loader', icon: uploadIcon, content: <DataLoader /> },
   { label: 'Linked accounts', icon: linkedAccountsIcon, content: <LinkedAccounts /> },
   { label: 'Invoices', icon: invoicesIcon, content: <Invoices /> },
   { label: 'Credentials', icon: credentialsIcon, content: <Credentials /> },

--- a/src/pages/DataLoader/components/Selector/Selector.tsx
+++ b/src/pages/DataLoader/components/Selector/Selector.tsx
@@ -7,6 +7,7 @@ import { ToastContainer } from 'react-toastify';
 import type { Catalog } from 'stac-js';
 
 import Refresh from '@/assets/icons/refresh.svg';
+import Warning from '@/assets/icons/warning.svg';
 import { Button } from '@/components/Button/Button';
 import { useDataLoader } from '@/hooks/useDataLoader';
 import { useWorkspace } from '@/hooks/useWorkspace';
@@ -56,7 +57,6 @@ const Selector = ({ catalogues }: SelectorProps) => {
     })[0];
     setSelectedCatalog(catalog);
 
-    setMessage('Catalogue not found'); // Warning message
     if (!catalog.links.length) return;
 
     const collectionLink = catalog.links.filter((link) => link.rel === 'collections')[0]?.href;
@@ -91,28 +91,42 @@ const Selector = ({ catalogues }: SelectorProps) => {
   const renderCataloguesSelector = () => {
     if (!selectedCatalog) return;
 
-    const selfLink = selectedCatalog.links.filter((link) => {
-      return link.rel === 'self';
-    })[0];
-    const selectedId = selfLink.href.split(`${activeWorkspace.name}/catalogs/`)[1];
-
+    // If there are no collections, show a warning above the dropdown
     return (
-      <div className="selector-catalogs">
-        <h3>Please select a Catalogue</h3>
-        <select value={selectedId} onChange={(e) => onCatalogueSelect(e.target.value)}>
-          {catalogues.map((catalog) => {
-            const selfLink = catalog.links.filter((link) => {
-              return link.rel === 'self';
-            })[0];
-            const id = selfLink.href.split(`${activeWorkspace.name}/catalogs/`)[1];
+      <div>
+        {collections.length === 0 && (
+          <div className="selector-warning-container">
+            <div className="selector-warning">
+              <img alt="Warning Icon" src={Warning} />
+              <span>
+                No collections found in <strong>{selectedCatalog.id}</strong>.<br />
+                Please add a new collection or click refresh—to populate collections.
+              </span>
+            </div>
+          </div>
+        )}
+
+        <div className="selector-catalogs">
+          <h3>Please select a Catalogue</h3>
+          {(() => {
+            const selfLink = selectedCatalog.links.filter((link) => link.rel === 'self')[0];
+            const selectedId = selfLink.href.split(`${activeWorkspace.name}/catalogs/`)[1];
             return (
-              <option key={id} value={id}>
-                {id}
-              </option>
+              <select value={selectedId} onChange={(e) => onCatalogueSelect(e.target.value)}>
+                {catalogues.map((catalog) => {
+                  const selfLinkInner = catalog.links.filter((link) => link.rel === 'self')[0];
+                  const id = selfLinkInner.href.split(`${activeWorkspace.name}/catalogs/`)[1];
+                  return (
+                    <option key={id} value={id}>
+                      {id}
+                    </option>
+                  );
+                })}
+              </select>
             );
-          })}
-        </select>
-        <ToastContainer hideProgressBar position="bottom-left" theme="light" />
+          })()}
+          <ToastContainer hideProgressBar position="bottom-left" theme="light" />
+        </div>
       </div>
     );
   };
@@ -240,19 +254,22 @@ const Selector = ({ catalogues }: SelectorProps) => {
 
     if (selectedCatalog) {
       buttons.push(
-        <Button onClick={() => window.open(catalogSelf.href, '_blank')}>
+        <Button key="view-catalog" onClick={() => window.open(catalogSelf.href, '_blank')}>
           View {selectedCatalog.id} catalog data
         </Button>,
       );
     }
     if (selectedCollection) {
       buttons.push(
-        <Button onClick={() => window.open(collectionSelf.href, '_blank')}>
+        <Button key="view-collection" onClick={() => window.open(collectionSelf.href, '_blank')}>
           View {selectedCollection.id} collection data
         </Button>,
       );
       buttons.push(
-        <Button onClick={() => window.open(`${collectionSelf.href}/items`, '_blank')}>
+        <Button
+          key="view-item"
+          onClick={() => window.open(`${collectionSelf.href}/items`, '_blank')}
+        >
           View {selectedCollection.id} item data
         </Button>,
       );

--- a/src/pages/DataLoader/components/Selector/styles.scss
+++ b/src/pages/DataLoader/components/Selector/styles.scss
@@ -25,6 +25,48 @@ $width: 600px;
     }
   }
 
+  &-warning {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background: #fff3cd;
+    padding: 8px 12px;
+    border-radius: 4px;
+    color: #856404;
+    text-align: center;
+    margin-top: 25px;
+
+    .selector-warning img {
+      position: absolute;
+      top: 50%;
+      left: 12px;
+      transform: translateY(-50%);
+      width: 24px;
+      height: 24px;
+      border: 0;
+    }
+
+    span {
+      order: 1;
+      line-height: 1.4;
+      margin-left: 32px;
+    }
+
+    strong {
+      font-weight: 600;
+    }
+  }
+
+  & &-warning img {
+    position: absolute;
+    top: 20px;
+    left: 15px;
+    width: 40px;
+    height: 40px;
+    border: 0;
+  }
+
   select {
     background-color: var(--background);
     color: var(--text-primary);

--- a/src/pages/DataLoader/components/Tutorial/DataLoaderTutorial.tsx
+++ b/src/pages/DataLoader/components/Tutorial/DataLoaderTutorial.tsx
@@ -5,13 +5,14 @@ import './styles.scss';
 const DataLoaderTutorial = () => {
   return (
     <div className="data-loader-tutorial">
-      <h1>Data Loader</h1>
+      <h1>Metadata Loader</h1>
       <div className="data-loader__tutorial">
-        <h2>How to Use the STAC Data Loader</h2>
+        <h2>How to Use the STAC Metadata Loader</h2>
         <p>
-          The STAC Data Loader helps you create STAC Collections and load STAC Items in bulk. Each
-          STAC Item is automatically validated to ensure it meets the required format, then uploaded
-          to your workspace, which stores the data and makes it accessible via a unique URL.
+          The STAC Metadata Loader helps you create STAC Collections and load STAC Items in bulk.
+          Each STAC Item is automatically validated to ensure it meets the required format, then
+          uploaded to your workspace, which stores the data and makes it accessible via a unique
+          URL.
         </p>
 
         <div>

--- a/src/pages/DataLoader/styles.scss
+++ b/src/pages/DataLoader/styles.scss
@@ -125,4 +125,8 @@ $width: 600px;
       cursor: not-allowed;
     }
   }
+
+  .data-loader-run-button {
+    min-width: 120px;
+  }
 }


### PR DESCRIPTION
- Renamed all user‐facing “Data Loader” strings to “Metadata Loader” in headers, descriptions, and tabs.

- Added an orange warning box in Selector.tsx that appears whenever a selected catalog has zero collections, hiding the dropdown.

- Replaced the multi-stage Validate/Upload/Harvest button with a single “Run” button that sequentially validates, uploads, and harvests, then conditionally shows “View data” once harvesting completes.