### PR TITLE
handle createWorkspace errors better

### DIFF
--- a/src/services/workspaces/workspaces.ts
+++ b/src/services/workspaces/workspaces.ts
@@ -7,7 +7,22 @@ export const createWorkspace = async (workspace: WorkspaceAdd) => {
       body: JSON.stringify(workspace),
     });
     if (!res.ok) {
-      throw new Error(res.statusText);
+      let message = 'Something went wrong';
+
+      switch (res.status) {
+        case 409:
+          message =
+            'A workspace with this name already exists. Please choose a different unique name.';
+          break;
+        case 500:
+          message =
+            'Server error. Try again later or alternatively email enquiries@eodatahub.org.uk and we will assist you.';
+          break;
+        default:
+          message = `Unexpected error. Kindly email enquiries@eodatahub.org.uk to raise this issue.`;
+      }
+
+      throw new Error(message);
     }
   } catch (error) {
     throw new Error(error);


### PR DESCRIPTION
Better handling of `createWorkspace` response codes to better inform users of any issues when they create their workspace. Previously it just threw the error object with no actual details.