### PR TITLE
Add Open Cosmos integration flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,6 @@
 VITE_WORKSPACE_LOCAL=true
+VITE_OPEN_COSMOS_AUTH_DOMAIN=https://login.open-cosmos.com
+VITE_OPEN_COSMOS_AUDIENCE=https://beeapp.open-cosmos.com
+VITE_OPEN_COSMOS_REDIRECT_URI=https://eodatahub.org.uk/workspaces/
+VITE_OPEN_COSMOS_SCOPE=openid profile email offline_access
+VITE_OPEN_COSMOS_CLIENT_ID=

--- a/src/components/WorkspaceMenu/WorkspaceMenu.tsx
+++ b/src/components/WorkspaceMenu/WorkspaceMenu.tsx
@@ -10,6 +10,23 @@ import { useWorkspace } from '../../hooks/useWorkspace';
 
 import './WorkspaceMenu.scss';
 
+const SELECTED_MENU_PATH_STORAGE_KEY = 'workspaceUiSelectedMenuPath';
+
+const findNavItemByPath = (items: NavItem[], path: string[]): NavItem | undefined => {
+  if (!path.length) return undefined;
+
+  let currentItems = items;
+  let foundItem: NavItem | undefined;
+
+  for (const segment of path) {
+    foundItem = currentItems.find((item) => item.label === segment);
+    if (!foundItem) return undefined;
+    currentItems = foundItem.subItems ?? [];
+  }
+
+  return foundItem;
+};
+
 export const WorkspaceMenu = () => {
   const { selectedItemPath, setSelectedItemPath, setContent } = useWorkspace();
 
@@ -17,10 +34,22 @@ export const WorkspaceMenu = () => {
 
   useEffect(() => {
     if (navItems.length > 0) {
-      setSelectedItemPath([navItems[0].label]);
-      setContent(navItems[0].content || <ComingSoon title={navItems[0].label} />);
+      const storedPath = localStorage.getItem(SELECTED_MENU_PATH_STORAGE_KEY);
+      const parsedPath = storedPath ? storedPath.split('/').filter(Boolean) : [];
+      const matchedItem = findNavItemByPath(navItems, parsedPath);
+
+      const initialPath = matchedItem ? parsedPath : [navItems[0].label];
+      const initialItem = matchedItem ?? navItems[0];
+
+      setSelectedItemPath(initialPath);
+      setContent(initialItem.content || <ComingSoon title={initialItem.label} />);
     }
   }, [setContent, setSelectedItemPath]);
+
+  useEffect(() => {
+    if (!selectedItemPath.length) return;
+    localStorage.setItem(SELECTED_MENU_PATH_STORAGE_KEY, selectedItemPath.join('/'));
+  }, [selectedItemPath]);
 
   const handleToggle = (label: string) => {
     setExpandedSet((prev) => {

--- a/src/context/OpenCosmosAuthContext/OpenCosmosAuthContext.tsx
+++ b/src/context/OpenCosmosAuthContext/OpenCosmosAuthContext.tsx
@@ -185,16 +185,21 @@ export const OpenCosmosAuthProvider = ({
       if (!nextSession.refreshToken) {
         throw new Error('Open Cosmos did not return a refresh token.');
       }
-      if (!nextSession.user?.sub) {
-        throw new Error('Open Cosmos did not return a user subject.');
-      }
+
+      const sessionPayload = {
+        accessToken: nextSession.accessToken,
+        refreshToken: nextSession.refreshToken,
+        expiresAt: nextSession.expiresAt,
+        scope: nextSession.scope,
+        tokenType: nextSession.tokenType,
+      };
 
       const response = await fetch(
         `/api/workspaces/${encodeURIComponent(workspaceName)}/open-cosmos/session`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(nextSession),
+          body: JSON.stringify(sessionPayload),
         },
       );
 

--- a/src/context/OpenCosmosAuthContext/OpenCosmosAuthContext.tsx
+++ b/src/context/OpenCosmosAuthContext/OpenCosmosAuthContext.tsx
@@ -1,0 +1,405 @@
+import { ReactNode, createContext, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { toast } from 'react-toastify';
+
+import { useWorkspace } from '@/hooks/useWorkspace';
+
+export interface OpenCosmosUser {
+  sub?: string;
+  name?: string;
+  email?: string;
+}
+
+type OpenCosmosAuthContextType = {
+  isConnected: boolean;
+  isLoading: boolean;
+  hasConfiguration: boolean;
+  error?: string;
+  user?: OpenCosmosUser;
+  connect: (returnTo?: string) => Promise<void>;
+  disconnect: () => void;
+  getAccessToken: () => Promise<string | undefined>;
+};
+
+type OpenCosmosProviderProps = {
+  initialState?: Partial<OpenCosmosAuthContextType>;
+  children: ReactNode;
+};
+
+interface OpenCosmosSession {
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt: number;
+  scope?: string;
+  tokenType?: string;
+  user?: OpenCosmosUser;
+}
+
+interface OpenCosmosTransaction {
+  codeVerifier: string;
+  returnTo: string;
+  workspaceName: string;
+}
+
+interface TokenExchangeResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  scope?: string;
+  token_type?: string;
+  id_token?: string;
+}
+
+const OPEN_COSMOS_AUTH_DOMAIN = import.meta.env.VITE_OPEN_COSMOS_AUTH_DOMAIN as string | undefined;
+const OPEN_COSMOS_CLIENT_ID = import.meta.env.VITE_OPEN_COSMOS_CLIENT_ID as string | undefined;
+const OPEN_COSMOS_AUDIENCE = import.meta.env.VITE_OPEN_COSMOS_AUDIENCE as string | undefined;
+const OPEN_COSMOS_REDIRECT_URI = import.meta.env.VITE_OPEN_COSMOS_REDIRECT_URI as
+  | string
+  | undefined;
+const OPEN_COSMOS_SCOPE =
+  (import.meta.env.VITE_OPEN_COSMOS_SCOPE as string | undefined) ??
+  'openid profile email offline_access';
+
+const TRANSACTION_STORAGE_KEY = 'openCosmosAuthTransaction';
+const TOKEN_EXPIRY_BUFFER_MS = 60 * 1000;
+const CODE_VERIFIER_BYTE_LENGTH = 64;
+
+export const OpenCosmosAuthContext = createContext<OpenCosmosAuthContextType | null>(null);
+OpenCosmosAuthContext.displayName = 'OpenCosmosAuthContext';
+
+const getRedirectUri = () =>
+  OPEN_COSMOS_REDIRECT_URI || `${window.location.origin}${window.location.pathname}`;
+
+const getDefaultReturnTo = () => `${window.location.pathname}${window.location.search}`;
+
+const persistTransaction = (transaction: OpenCosmosTransaction) => {
+  sessionStorage.setItem(TRANSACTION_STORAGE_KEY, JSON.stringify(transaction));
+};
+
+const readTransaction = (): OpenCosmosTransaction | undefined => {
+  const stored = sessionStorage.getItem(TRANSACTION_STORAGE_KEY);
+  if (!stored) return undefined;
+
+  try {
+    return JSON.parse(stored) as OpenCosmosTransaction;
+  } catch {
+    sessionStorage.removeItem(TRANSACTION_STORAGE_KEY);
+    return undefined;
+  }
+};
+
+const clearTransaction = () => {
+  sessionStorage.removeItem(TRANSACTION_STORAGE_KEY);
+};
+
+const base64UrlEncode = (bytes: Uint8Array) => {
+  const base64 = btoa(String.fromCharCode(...bytes));
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+};
+
+const generateRandomString = (length: number) => {
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+  return base64UrlEncode(bytes);
+};
+
+const createCodeChallenge = async (verifier: string) => {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+  return base64UrlEncode(new Uint8Array(digest));
+};
+
+const parseJwtPayload = (token?: string): OpenCosmosUser | undefined => {
+  if (!token) return undefined;
+
+  const [, payload] = token.split('.');
+  if (!payload) return undefined;
+
+  try {
+    const normalized = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), '=');
+    const decoded = atob(padded);
+    return JSON.parse(decoded) as OpenCosmosUser;
+  } catch {
+    return undefined;
+  }
+};
+
+const buildSession = (
+  tokenResponse: TokenExchangeResponse,
+  fallbackUser?: OpenCosmosUser,
+): OpenCosmosSession => ({
+  accessToken: tokenResponse.access_token,
+  refreshToken: tokenResponse.refresh_token,
+  expiresAt: Date.now() + tokenResponse.expires_in * 1000,
+  scope: tokenResponse.scope,
+  tokenType: tokenResponse.token_type,
+  user:
+    parseJwtPayload(tokenResponse.id_token) ??
+    parseJwtPayload(tokenResponse.access_token) ??
+    fallbackUser,
+});
+
+const isSessionActive = (session?: OpenCosmosSession) => {
+  if (!session?.accessToken) return false;
+  return session.expiresAt - TOKEN_EXPIRY_BUFFER_MS > Date.now();
+};
+
+export const OpenCosmosAuthProvider = ({
+  initialState = {},
+  children,
+}: OpenCosmosProviderProps) => {
+  const { activeWorkspace } = useWorkspace();
+  const callbackHandledRef = useRef(false);
+  const [session, setSession] = useState<OpenCosmosSession>();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string>();
+
+  const hasConfiguration = useMemo(
+    () => Boolean(OPEN_COSMOS_AUTH_DOMAIN && OPEN_COSMOS_CLIENT_ID && OPEN_COSMOS_AUDIENCE),
+    [],
+  );
+
+  const exchangeToken = useCallback(async (params: URLSearchParams) => {
+    if (!OPEN_COSMOS_AUTH_DOMAIN) {
+      throw new Error('Open Cosmos authentication is not configured.');
+    }
+
+    const response = await fetch(new URL('/oauth/token', OPEN_COSMOS_AUTH_DOMAIN), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: params.toString(),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(errorText || 'Open Cosmos token exchange failed.');
+    }
+
+    return (await response.json()) as TokenExchangeResponse;
+  }, []);
+
+  const storeSession = useCallback(
+    async (workspaceName: string, nextSession: OpenCosmosSession) => {
+      if (!nextSession.refreshToken) {
+        throw new Error('Open Cosmos did not return a refresh token.');
+      }
+      if (!nextSession.user?.sub) {
+        throw new Error('Open Cosmos did not return a user subject.');
+      }
+
+      const response = await fetch(
+        `/api/workspaces/${encodeURIComponent(workspaceName)}/open-cosmos/session`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(nextSession),
+        },
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(errorText || 'Unable to store the Open Cosmos session.');
+      }
+    },
+    [],
+  );
+
+  const refreshSession = useCallback(async () => {
+    if (!session?.refreshToken || !OPEN_COSMOS_CLIENT_ID) {
+      return undefined;
+    }
+
+    const params = new URLSearchParams({
+      grant_type: 'refresh_token',
+      client_id: OPEN_COSMOS_CLIENT_ID,
+      refresh_token: session.refreshToken,
+    });
+
+    const tokenResponse = await exchangeToken(params);
+    const nextSession = buildSession(tokenResponse, session.user);
+    if (!nextSession.refreshToken) {
+      nextSession.refreshToken = session.refreshToken;
+    }
+
+    if (!activeWorkspace?.name) {
+      throw new Error('Select a workspace before refreshing the Open Cosmos session.');
+    }
+
+    await storeSession(activeWorkspace.name, nextSession);
+    setSession(nextSession);
+    setError(undefined);
+
+    return nextSession;
+  }, [activeWorkspace?.name, exchangeToken, session, storeSession]);
+
+  useEffect(() => {
+    if (!hasConfiguration) return;
+
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get('code');
+    const oauthError = params.get('error');
+
+    if (!code && !oauthError) return;
+    if (callbackHandledRef.current) return;
+
+    // OAuth authorization codes are single-use. StrictMode runs effects twice in development,
+    // so mark this callback as handled before starting the asynchronous token exchange.
+    callbackHandledRef.current = true;
+
+    const handleCallback = async () => {
+      setIsLoading(true);
+
+      try {
+        if (oauthError) {
+          throw new Error(params.get('error_description') ?? 'Open Cosmos sign-in failed.');
+        }
+
+        if (!code) {
+          throw new Error('Open Cosmos callback is missing the authorization code.');
+        }
+
+        const transaction = readTransaction();
+        if (!transaction) {
+          throw new Error('Open Cosmos sign-in session was not found.');
+        }
+
+        if (!OPEN_COSMOS_CLIENT_ID) {
+          throw new Error('Open Cosmos OAuth configuration is incomplete.');
+        }
+
+        const body = new URLSearchParams({
+          grant_type: 'authorization_code',
+          client_id: OPEN_COSMOS_CLIENT_ID,
+          code,
+          code_verifier: transaction.codeVerifier,
+          redirect_uri: getRedirectUri(),
+        });
+
+        const tokenResponse = await exchangeToken(body);
+        const nextSession = buildSession(tokenResponse);
+
+        await storeSession(transaction.workspaceName, nextSession);
+        setSession(nextSession);
+        setError(undefined);
+        clearTransaction();
+
+        window.history.replaceState(
+          {},
+          document.title,
+          transaction.returnTo || getDefaultReturnTo(),
+        );
+      } catch (callbackError) {
+        clearTransaction();
+        setSession(undefined);
+
+        const message =
+          callbackError instanceof Error ? callbackError.message : 'Open Cosmos sign-in failed.';
+        setError(message);
+        toast.error(message);
+        window.history.replaceState({}, document.title, getDefaultReturnTo());
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void handleCallback();
+  }, [exchangeToken, hasConfiguration, storeSession]);
+
+  const connect = useCallback(
+    async (returnTo?: string) => {
+      if (!hasConfiguration || !OPEN_COSMOS_AUTH_DOMAIN || !OPEN_COSMOS_CLIENT_ID) {
+        const message = 'Open Cosmos authentication is not configured.';
+        setError(message);
+        toast.error(message);
+        return;
+      }
+
+      setIsLoading(true);
+      setError(undefined);
+
+      try {
+        if (!activeWorkspace?.name) {
+          throw new Error('Select a workspace before connecting Open Cosmos.');
+        }
+
+        const codeVerifier = generateRandomString(CODE_VERIFIER_BYTE_LENGTH);
+        const codeChallenge = await createCodeChallenge(codeVerifier);
+
+        persistTransaction({
+          codeVerifier,
+          returnTo: returnTo ?? getDefaultReturnTo(),
+          workspaceName: activeWorkspace.name,
+        });
+
+        const authorizeUrl = new URL('/authorize', OPEN_COSMOS_AUTH_DOMAIN);
+        authorizeUrl.searchParams.set('response_type', 'code');
+        authorizeUrl.searchParams.set('client_id', OPEN_COSMOS_CLIENT_ID);
+        authorizeUrl.searchParams.set('redirect_uri', getRedirectUri());
+        authorizeUrl.searchParams.set('scope', OPEN_COSMOS_SCOPE);
+        authorizeUrl.searchParams.set('code_challenge', codeChallenge);
+        authorizeUrl.searchParams.set('code_challenge_method', 'S256');
+
+        if (OPEN_COSMOS_AUDIENCE) {
+          authorizeUrl.searchParams.set('audience', OPEN_COSMOS_AUDIENCE);
+        }
+
+        window.location.assign(authorizeUrl.toString());
+      } catch (connectError) {
+        const message =
+          connectError instanceof Error
+            ? connectError.message
+            : 'Unable to start Open Cosmos sign-in.';
+        setError(message);
+        setIsLoading(false);
+        toast.error(message);
+      }
+    },
+    [activeWorkspace?.name, hasConfiguration],
+  );
+
+  const disconnect = useCallback(() => {
+    clearTransaction();
+    setSession(undefined);
+    setError(undefined);
+  }, []);
+
+  const getAccessToken = useCallback(async () => {
+    if (isSessionActive(session)) {
+      return session?.accessToken;
+    }
+
+    try {
+      const refreshedSession = await refreshSession();
+      return refreshedSession?.accessToken;
+    } catch (refreshError) {
+      disconnect();
+      const message =
+        refreshError instanceof Error
+          ? refreshError.message
+          : 'Open Cosmos session refresh failed.';
+      setError(message);
+      toast.error(message);
+      return undefined;
+    }
+  }, [disconnect, refreshSession, session]);
+
+  return (
+    <OpenCosmosAuthContext.Provider
+      value={{
+        isConnected: Boolean(session?.accessToken),
+        isLoading,
+        hasConfiguration,
+        error,
+        user: session?.user,
+        connect,
+        disconnect,
+        getAccessToken,
+        ...initialState,
+      }}
+    >
+      {children}
+    </OpenCosmosAuthContext.Provider>
+  );
+};

--- a/src/hooks/useOpenCosmosAuth.ts
+++ b/src/hooks/useOpenCosmosAuth.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+
+import { OpenCosmosAuthContext } from '@/context/OpenCosmosAuthContext/OpenCosmosAuthContext';
+
+export const useOpenCosmosAuth = () => {
+  const context = useContext(OpenCosmosAuthContext);
+  if (!context) {
+    throw new Error('useOpenCosmosAuth must be used within an OpenCosmosAuthProvider');
+  }
+  return context;
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import { App } from './App';
 import './index.scss';
 import { DataLoaderProvider } from './context/DataLoaderContext/DataLoaderContext';
 import { InvoicesProvider } from './context/InvoicesContext/InvoicesContext';
+import { OpenCosmosAuthProvider } from './context/OpenCosmosAuthContext/OpenCosmosAuthContext';
 import { WorkspaceProvider } from './context/WorkspaceContext/WorkspaceContext';
 
 const enableMocking = async () => {
@@ -26,11 +27,13 @@ enableMocking().then(() => {
   createRoot(document.getElementById('root')!).render(
     <StrictMode>
       <WorkspaceProvider>
-        <DataLoaderProvider>
-          <InvoicesProvider>
-            <App />
-          </InvoicesProvider>
-        </DataLoaderProvider>
+        <OpenCosmosAuthProvider>
+          <DataLoaderProvider>
+            <InvoicesProvider>
+              <App />
+            </InvoicesProvider>
+          </DataLoaderProvider>
+        </OpenCosmosAuthProvider>
       </WorkspaceProvider>
     </StrictMode>,
   );

--- a/src/pages/LinkedAccounts/LinkedAccounts.tsx
+++ b/src/pages/LinkedAccounts/LinkedAccounts.tsx
@@ -10,6 +10,7 @@ import Tick from '@/assets/icons/tick.svg';
 import { Button } from '@/components/Button/Button';
 import Modal from '@/components/Modal/Modal';
 import Help from '@/components/Table/Components/Help/Help';
+import { useOpenCosmosAuth } from '@/hooks/useOpenCosmosAuth';
 import { useWorkspace } from '@/hooks/useWorkspace';
 
 type LinkableAccount = {
@@ -96,6 +97,15 @@ const linkableAccounts: LinkableAccount[] = [
 
 const LinkedAccounts = () => {
   const { activeWorkspace, isWorkspaceOwner } = useWorkspace();
+  const {
+    isConnected: isOpenCosmosConnected,
+    isLoading: isOpenCosmosLoading,
+    hasConfiguration: hasOpenCosmosConfiguration,
+    user: openCosmosUser,
+    error: openCosmosError,
+    connect: connectOpenCosmos,
+    disconnect: disconnectOpenCosmos,
+  } = useOpenCosmosAuth();
 
   const [error, setError] = useState('');
   const [data, setData] = useState<AccountMetaData[]>([]);
@@ -226,6 +236,60 @@ const LinkedAccounts = () => {
           <div className="linked-accounts__success">API key is valid</div>
         )}
         {renderButton(account)}
+      </div>
+    );
+  };
+
+  const renderOpenCosmosAccount = () => {
+    const statusText = !hasOpenCosmosConfiguration
+      ? 'Unavailable'
+      : isOpenCosmosConnected
+        ? 'Connected'
+        : 'Not connected';
+
+    const description = isOpenCosmosConnected
+      ? openCosmosUser?.email ||
+        openCosmosUser?.name ||
+        'Open Cosmos is connected for this workspace'
+      : 'Sign in to enable Open Cosmos services for this workspace.';
+
+    return (
+      <div className="linked-accounts__account linked-accounts__account--oauth">
+        <div className="linked-accounts__account-header">
+          Open Cosmos <span>| {statusText}</span>
+          <div className="linked-accounts__account-modal">
+            <Help
+              content={
+                <p>
+                  Sign in with your Open Cosmos account to make your credentials available to EODH
+                  commercial data flows. The credentials are stored securely for your Open Cosmos
+                  user in the selected workspace.
+                </p>
+              }
+              type="Modal"
+            />
+          </div>
+        </div>
+        <div className="linked-accounts__account-note">{description}</div>
+        {openCosmosError ? (
+          <div className="linked-accounts__error linked-accounts__error--inline">
+            {openCosmosError}
+          </div>
+        ) : null}
+        <div className="linked-accounts__account-actions">
+          {isOpenCosmosConnected ? (
+            <Button disabled={isOpenCosmosLoading} onClick={disconnectOpenCosmos}>
+              Disconnect
+            </Button>
+          ) : (
+            <Button
+              disabled={!hasOpenCosmosConfiguration || isOpenCosmosLoading}
+              onClick={() => connectOpenCosmos(window.location.href)}
+            >
+              Connect Open Cosmos
+            </Button>
+          )}
+        </div>
       </div>
     );
   };
@@ -526,7 +590,8 @@ const LinkedAccounts = () => {
               border: '1px solid #faebcc',
             }}
           >
-            You have view-only access. Only workspace owners can edit or link API keys.
+            You have view-only access. Only workspace owners can edit or link provider API keys.
+            Open Cosmos credentials are stored per user in the selected workspace.
           </div>
         )}
         {<div className="linked-accounts__error">{error}</div>}
@@ -534,6 +599,7 @@ const LinkedAccounts = () => {
           {data.map((account) => (
             <div key={account.internalName}>{renderAccount(account)}</div>
           ))}
+          {renderOpenCosmosAccount()}
         </div>
         <ToastContainer hideProgressBar position="bottom-left" theme="light" />
       </div>

--- a/src/pages/LinkedAccounts/LinkedAccounts.tsx
+++ b/src/pages/LinkedAccounts/LinkedAccounts.tsx
@@ -262,8 +262,7 @@ const LinkedAccounts = () => {
               content={
                 <p>
                   Sign in with your Open Cosmos account to make your credentials available to EODH
-                  commercial data flows. The credentials are stored securely for your Open Cosmos
-                  user in the selected workspace.
+                  commercial data flows. The session is stored for the selected workspace.
                 </p>
               }
               type="Modal"
@@ -591,7 +590,7 @@ const LinkedAccounts = () => {
             }}
           >
             You have view-only access. Only workspace owners can edit or link provider API keys.
-            Open Cosmos credentials are stored per user in the selected workspace.
+            Open Cosmos sign-in is stored for the selected workspace.
           </div>
         )}
         {<div className="linked-accounts__error">{error}</div>}

--- a/src/pages/LinkedAccounts/styles.scss
+++ b/src/pages/LinkedAccounts/styles.scss
@@ -6,6 +6,11 @@
     flex-direction: column;
     gap: 10px;
 
+    &--oauth {
+      border-bottom: none;
+      padding-bottom: 0;
+    }
+
     &-header {
       display: flex;
       align-items: center;
@@ -44,7 +49,8 @@
     }
 
     button {
-      width: 120px;
+      min-width: 120px;
+      width: fit-content;
       height: 30px;
 
       &:disabled {
@@ -53,8 +59,23 @@
     }
   }
 
+  &__account-note {
+    max-width: 720px;
+    color: var(--text-secondary);
+    line-height: 1.5;
+  }
+
+  &__account-actions {
+    display: flex;
+    gap: 10px;
+  }
+
   &__error {
     color: var(--error);
+
+    &--inline {
+      margin-top: -4px;
+    }
   }
 
   &__success {


### PR DESCRIPTION
## Summary
Adds Open Cosmos account connection support to the Linked Accounts page using the OAuth 2.0 Authorization Code flow with PKCE (Proof Key for Code Exchange).

## Changes

- Add Open Cosmos connect and disconnect controls.
- Exchange authorization codes and refresh expired access tokens.
- Send OAuth credentials to workspace-services for per-user, per-workspace storage.
- Keep tokens out of browser persistent storage.
- Restore the selected workspace menu page after the OAuth redirect. (src\components\WorkspaceMenu\WorkspaceMenu.tsx)
- Prevent duplicate authorization-code exchanges in React StrictMode.
- Add the required Open Cosmos environment configuration (new env vars).

## Validation
<img width="1902" height="962" alt="image" src="https://github.com/user-attachments/assets/4350db8a-f5de-4127-bd2b-1e84968f1627" />

<img width="1853" height="903" alt="image" src="https://github.com/user-attachments/assets/97556364-4249-4aa7-9bb3-9a84318728b5" />

<img width="1862" height="905" alt="image" src="https://github.com/user-attachments/assets/4f1a2a94-60a5-42f1-a055-edeb26f0fb7b" />
