### PR TITLE
Add organization id to open cosmos flow

### DIFF
--- a/src/context/OpenCosmosAuthContext/OpenCosmosAuthContext.tsx
+++ b/src/context/OpenCosmosAuthContext/OpenCosmosAuthContext.tsx
@@ -16,7 +16,7 @@ type OpenCosmosAuthContextType = {
   hasConfiguration: boolean;
   error?: string;
   user?: OpenCosmosUser;
-  connect: (returnTo?: string) => Promise<void>;
+  connect: (returnTo?: string, organizationId?: number) => Promise<void>;
   disconnect: () => void;
   getAccessToken: () => Promise<string | undefined>;
 };
@@ -33,12 +33,14 @@ interface OpenCosmosSession {
   scope?: string;
   tokenType?: string;
   user?: OpenCosmosUser;
+  organizationId?: number;
 }
 
 interface OpenCosmosTransaction {
   codeVerifier: string;
   returnTo: string;
   workspaceName: string;
+  organizationId: number;
 }
 
 interface TokenExchangeResponse {
@@ -185,6 +187,9 @@ export const OpenCosmosAuthProvider = ({
       if (!nextSession.refreshToken) {
         throw new Error('Open Cosmos did not return a refresh token.');
       }
+      if (nextSession.organizationId === undefined) {
+        throw new Error('Open Cosmos organization ID is required.');
+      }
 
       const sessionPayload = {
         accessToken: nextSession.accessToken,
@@ -192,6 +197,7 @@ export const OpenCosmosAuthProvider = ({
         expiresAt: nextSession.expiresAt,
         scope: nextSession.scope,
         tokenType: nextSession.tokenType,
+        organization_id: nextSession.organizationId,
       };
 
       const response = await fetch(
@@ -223,7 +229,10 @@ export const OpenCosmosAuthProvider = ({
     });
 
     const tokenResponse = await exchangeToken(params);
-    const nextSession = buildSession(tokenResponse, session.user);
+    const nextSession = {
+      ...buildSession(tokenResponse, session.user),
+      organizationId: session.organizationId,
+    };
     if (!nextSession.refreshToken) {
       nextSession.refreshToken = session.refreshToken;
     }
@@ -283,7 +292,10 @@ export const OpenCosmosAuthProvider = ({
         });
 
         const tokenResponse = await exchangeToken(body);
-        const nextSession = buildSession(tokenResponse);
+        const nextSession = {
+          ...buildSession(tokenResponse),
+          organizationId: transaction.organizationId,
+        };
 
         await storeSession(transaction.workspaceName, nextSession);
         setSession(nextSession);
@@ -313,7 +325,7 @@ export const OpenCosmosAuthProvider = ({
   }, [exchangeToken, hasConfiguration, storeSession]);
 
   const connect = useCallback(
-    async (returnTo?: string) => {
+    async (returnTo?: string, organizationId?: number) => {
       if (!hasConfiguration || !OPEN_COSMOS_AUTH_DOMAIN || !OPEN_COSMOS_CLIENT_ID) {
         const message = 'Open Cosmos authentication is not configured.';
         setError(message);
@@ -328,6 +340,9 @@ export const OpenCosmosAuthProvider = ({
         if (!activeWorkspace?.name) {
           throw new Error('Select a workspace before connecting Open Cosmos.');
         }
+        if (organizationId === undefined || organizationId < 0) {
+          throw new Error('Enter a valid Open Cosmos organization ID before connecting.');
+        }
 
         const codeVerifier = generateRandomString(CODE_VERIFIER_BYTE_LENGTH);
         const codeChallenge = await createCodeChallenge(codeVerifier);
@@ -336,6 +351,7 @@ export const OpenCosmosAuthProvider = ({
           codeVerifier,
           returnTo: returnTo ?? getDefaultReturnTo(),
           workspaceName: activeWorkspace.name,
+          organizationId,
         });
 
         const authorizeUrl = new URL('/authorize', OPEN_COSMOS_AUTH_DOMAIN);

--- a/src/pages/LinkedAccounts/LinkedAccounts.tsx
+++ b/src/pages/LinkedAccounts/LinkedAccounts.tsx
@@ -112,6 +112,7 @@ const LinkedAccounts = () => {
   const [running, setRunning] = useState<boolean>();
   const [modal, setModal] = useState<boolean>(false);
   const [accountToUnlink, setAccountToUnlink] = useState<AccountMetaData>();
+  const [openCosmosOrganizationId, setOpenCosmosOrganizationId] = useState('');
 
   const setMessage = (message: string) => {
     toast(message);
@@ -241,6 +242,8 @@ const LinkedAccounts = () => {
   };
 
   const renderOpenCosmosAccount = () => {
+    const parsedOrganizationId = Number(openCosmosOrganizationId);
+    const hasValidOrganizationId = /^\d+$/.test(openCosmosOrganizationId);
     const statusText = !hasOpenCosmosConfiguration
       ? 'Unavailable'
       : isOpenCosmosConnected
@@ -275,6 +278,20 @@ const LinkedAccounts = () => {
             {openCosmosError}
           </div>
         ) : null}
+        {!isOpenCosmosConnected ? (
+          <div className="linked-accounts__account-input">
+            <input
+              inputMode="numeric"
+              pattern="[0-9]*"
+              placeholder="Enter your Open Cosmos organization ID"
+              type="text"
+              value={openCosmosOrganizationId}
+              onChange={(event) => {
+                setOpenCosmosOrganizationId(event.target.value.replace(/\D/g, ''));
+              }}
+            />
+          </div>
+        ) : null}
         <div className="linked-accounts__account-actions">
           {isOpenCosmosConnected ? (
             <Button disabled={isOpenCosmosLoading} onClick={disconnectOpenCosmos}>
@@ -282,8 +299,10 @@ const LinkedAccounts = () => {
             </Button>
           ) : (
             <Button
-              disabled={!hasOpenCosmosConfiguration || isOpenCosmosLoading}
-              onClick={() => connectOpenCosmos(window.location.href)}
+              disabled={
+                !hasOpenCosmosConfiguration || isOpenCosmosLoading || !hasValidOrganizationId
+              }
+              onClick={() => connectOpenCosmos(window.location.href, parsedOrganizationId)}
             >
               Connect Open Cosmos
             </Button>


### PR DESCRIPTION
The workspace UI now requires users to enter an Open Cosmos organization ID before connecting, carries that value through the OAuth redirect, and includes it in the session payload sent to workspace-services.

<img width="1216" height="862" alt="image" src="https://github.com/user-attachments/assets/6bd1e66d-d898-4b78-b99f-0ca419b60311" />
<img width="1215" height="862" alt="image" src="https://github.com/user-attachments/assets/1097bc01-27e9-45bc-a5fc-0734dfe8be88" />
